### PR TITLE
Better naming: mainnet-> host chain

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -21,7 +21,7 @@
 
 ## App Deployment
 
-* [Deploy Smart Contract on Mainnet](app-deployment/local.md)
+* [Deploy Smart Contract on Host Chain](app-deployment/local.md)
 * [Publish Docker](app-deployment/publish-docker.md)
 * [Register into Sparsity](app-deployment/spin-contracts.md)
 * [Verification](app-deployment/spin-da.md)

--- a/app-deployment/local.md
+++ b/app-deployment/local.md
@@ -1,4 +1,4 @@
-# Deploy Smart Contract on Mainnet
+# Deploy Smart Contract on Host Chain
 
 ## Contract Deployment Guide
 

--- a/getting-started/create-a-new-project/app-abci-core.md
+++ b/getting-started/create-a-new-project/app-abci-core.md
@@ -92,4 +92,4 @@ Developers can define custom message formats, parse them, and process interactio
 ### Additional Features
 
 * **Accessing Block Height:** The `blockHeight` property allows developers to retrieve the latest block number for custom logic implementation.
-* **State Management & Smart Contract Integration:** By implementing these core functions, developers can define application behavior, manage state transitions, and seamlessly integrate with the Sparsity network and smart contracts on the mainnet.
+* **State Management & Smart Contract Integration:** By implementing these core functions, developers can define application behavior, manage state transitions, and seamlessly integrate with the Sparsity network and smart contracts on the host chain.

--- a/getting-started/create-a-new-project/app-smart-contract.md
+++ b/getting-started/create-a-new-project/app-smart-contract.md
@@ -58,7 +58,7 @@ A session represents the entire lifecycle of an app’s execution. It determines
 &#xNAN;**`initialData`** is the encoded data that the user passes to the Sparsity network when initializing the session.
 
 🔹 **Auth**\
-Auth verifies whether an address has permission to use Sparsity within a session. This information is eventually relayed from the mainnet to the Sparsity network, where the App ABCI Core can utilize it.
+Auth verifies whether an address has permission to use Sparsity within a session. This information is eventually relayed from the host chain to the Sparsity network, where the App ABCI Core can utilize it.
 
 🔹 **Settle**\
 When Sparsity completes its computation, the results are returned via a callback and recorded in the developer’s smart contract.

--- a/getting-started/system-architecture.md
+++ b/getting-started/system-architecture.md
@@ -6,9 +6,9 @@ description: Export and validate the gameplay for client & prover
 
 ## **Understanding the Sparsity System**
 
-Sparsity is built on two core components: the **Mainnet** and the **Sparsity Network**.
+Sparsity is built on two core components: the **Host Chain** and the **Sparsity Network**.
 
-* The **Mainnet** serves as the primary blockchain where applications operate.
+* The **Host Chain** serves as the primary blockchain where applications operate.
 * The **Sparsity Network** manages ephemeral roll-ups for off-chain computation.
 
 Currently, Sparsity supports most **EVM-compatible chains** (such as Base, Ethereum, and BNB Smart Chain) and will integrate non-EVM blockchains like **Solana** in the future.
@@ -23,10 +23,10 @@ This architecture connects three key participants:
 
 To integrate an application with Sparsity, the app developer/owner must:
 
-1️⃣ **Deploy the App Smart Contract** – The smart contract must be deployed on the Mainnet.\
-2️⃣ **Register the Smart Contract & ABCI Core** – Register the app’s smart contract and **public Docker-based ABCI core** with the Sparsity contract on the Mainnet.\
+1️⃣ **Deploy the App Smart Contract** – The smart contract must be deployed on the host chain.\
+2️⃣ **Register the Smart Contract & ABCI Core** – Register the app’s smart contract and **public Docker-based ABCI core** with the Sparsity contract on the host chain.\
 3️⃣ **Publish the App Client (Optional)** – If the app requires a user-facing interface, the developer may choose to publish an app client.\
-4️⃣ **Bridge Between Mainnet & Sparsity Network (Optional)** – Sparsity provides a built-in bridge, eliminating the need for custom implementations.
+4️⃣ **Bridge Between Host Chain & Sparsity Network (Optional)** – Sparsity provides a built-in bridge, eliminating the need for custom implementations.
 
 ### **Computing Resource Providers Workflow**
 
@@ -34,12 +34,12 @@ To integrate an application with Sparsity, the app developer/owner must:
 
 ### **How an App User Interacts with the App**
 
-1️⃣ **User Interaction** – The user interacts with the app’s smart contract on the Mainnet.\
-2️⃣ **Triggering Sparsity Contract** – The smart contract invokes the **Sparsity contract** on the Mainnet.\
+1️⃣ **User Interaction** – The user interacts with the app’s smart contract on the host chain.\
+2️⃣ **Triggering Sparsity Contract** – The smart contract invokes the **Sparsity contract** on the host chain.\
 3️⃣ **Resource Allocation** – The **Sparsity bridge** assigns computing resources and deploys the ephemeral roll-up within the Sparsity Network.\
-4️⃣ **Writing Back to Mainnet** – The **Sparsity bridge** writes roll-up machine details back to the app’s smart contract on the Mainnet.\
+4️⃣ **Writing Back to Host Chain** – The **Sparsity bridge** writes roll-up machine details back to the app’s smart contract on the host chain.\
 5️⃣ **Roll-Up Interaction** – The user interacts with the ephemeral roll-up via the app client and smart contract.\
-6️⃣ **Final Settlement** – Intermediate states and final computation results are written back to the Mainnet through the **Sparsity bridge**.
+6️⃣ **Final Settlement** – Intermediate states and final computation results are written back to the host chain through the **Sparsity bridge**.
 
 With Sparsity, developers can **effortlessly scale** their dApps, leveraging **decentralized infrastructure and high-performance computation** to create the next generation of Web3 applications! 🚀
 


### PR DESCRIPTION
To avoid confusion, we rename the mainnet as host chain